### PR TITLE
tweak tagSearch() and add a variable for default date format

### DIFF
--- a/src/MyNotes.py
+++ b/src/MyNotes.py
@@ -146,7 +146,7 @@ class Search(object):
         for f in sorted_file_list:
             content = self._getFileContent(f['path'])
             if content != str():
-                match_obj = re.search(r'\bTags:.*', content)
+                match_obj = re.search(r'\bTags:.*', content, re.IGNORECASE)
                 if match_obj:
                     r = match_obj.group(0)
                     results = re.findall(regex, r)
@@ -193,7 +193,7 @@ class Search(object):
         with open(file_path, 'r') as c:
             lines = c.readlines()[0:5]
         for l in lines:
-            match_obj = re.search(r'Tags:.*' + tag, l)
+            match_obj = re.search(r'Tags:.*' + tag, l, re.IGNORECASE)
             if match_obj:
                 match = True
                 break

--- a/src/MyNotes.py
+++ b/src/MyNotes.py
@@ -200,7 +200,7 @@ class Search(object):
         return match
 
     @staticmethod
-    def getTodayDate(fmt="%d.%m.%Y"):
+    def getTodayDate(fmt=Tools.getEnv('default_date_format')):
         now = datetime.datetime.now()
         return now.strftime(fmt)
 

--- a/src/info.plist
+++ b/src/info.plist
@@ -2014,6 +2014,8 @@ fi</string>
 		<string>#Template</string>
 		<key>url_scheme</key>
 		<string>x-marked://open/?file=</string>
+		<key>default_date_format</key>
+		<string>%d.%m.%Y</string>
 	</dict>
 	<key>variablesdontexport</key>
 	<array>


### PR DESCRIPTION
Hi
1) the tags format in yaml frontier is "Tags: " doesn't accept "tags: ", modify tagSearch() to ignore case.
2) add an alfred variable for default date format when creating md with {date} in template.
for example:
default is:%d.%m.%Y
can be changed to:%Y-%m-%d %H:%M:%S